### PR TITLE
Handle chat clear message

### DIFF
--- a/cmd/irc2text/irc2text.go
+++ b/cmd/irc2text/irc2text.go
@@ -17,12 +17,14 @@ func main() {
 			_, _ = fmt.Fprintf(os.Stderr, "Failed to irc parse message: %s\n", err)
 			os.Exit(1)
 		}
-		fmt.Printf("[%s] %s ", msg.Timestamp.UTC().Format("2006-01-02 15:04:05"), msg.Args[0])
 		if msg.Action == "PRIVMSG" {
+			fmt.Printf("[%s] %s ", msg.Timestamp.UTC().Format("2006-01-02 15:04:05"), msg.Args[0])
 			fmt.Printf("%s: %s\n", msg.User, msg.Args[1])
 		} else if msg.Action == "NOTICE" {
+			fmt.Printf("[%s] %s ", msg.Timestamp.UTC().Format("2006-01-02 15:04:05"), msg.Args[0])
 			fmt.Printf("NOTICE %s\n", msg.Args[1])
 		} else if msg.Action == "CLEARCHAT" {
+			fmt.Printf("[%s] %s ", msg.Timestamp.UTC().Format("2006-01-02 15:04:05"), msg.Args[0])
 			if len(msg.Args) < 2 {
 				fmt.Println("Chat has been cleared")
 			} else {

--- a/cmd/irc2text/irc2text.go
+++ b/cmd/irc2text/irc2text.go
@@ -22,11 +22,15 @@ func main() {
 		} else if msg.Action == "NOTICE" {
 			fmt.Printf("NOTICE %s %s\n", msg.Args[0], msg.Args[1])
 		} else if msg.Action == "CLEARCHAT" {
-			duration := msg.Tags["ban-duration"]
-			if duration == "" {
-				fmt.Printf("%s was permanently banned\n", msg.Args[1])
+			if len(msg.Args) < 2 {
+				fmt.Println("Chat has been cleared")
 			} else {
-				fmt.Printf("%s was timed out for %s seconds\n", msg.Args[1], msg.Tags["ban-duration"])
+				duration := msg.Tags["ban-duration"]
+				if duration == "" {
+					fmt.Printf("%s was permanently banned\n", msg.Args[1])
+				} else {
+					fmt.Printf("%s was timed out for %s seconds\n", msg.Args[1], duration)
+				}
 			}
 		}
 	}

--- a/cmd/irc2text/irc2text.go
+++ b/cmd/irc2text/irc2text.go
@@ -17,10 +17,11 @@ func main() {
 			_, _ = fmt.Fprintf(os.Stderr, "Failed to irc parse message: %s\n", err)
 			os.Exit(1)
 		}
+		fmt.Printf("[%s] %s ", msg.Timestamp.UTC().Format("2006-01-02 15:04:05"), msg.Args[0])
 		if msg.Action == "PRIVMSG" {
-			fmt.Printf("[%s] %s %s: %s\n", msg.Timestamp.UTC().Format("2006-01-02 15:04:05"), msg.Args[0], msg.User, msg.Args[1])
+			fmt.Printf("%s: %s\n", msg.User, msg.Args[1])
 		} else if msg.Action == "NOTICE" {
-			fmt.Printf("NOTICE %s %s\n", msg.Args[0], msg.Args[1])
+			fmt.Printf("NOTICE %s\n", msg.Args[1])
 		} else if msg.Action == "CLEARCHAT" {
 			if len(msg.Args) < 2 {
 				fmt.Println("Chat has been cleared")


### PR DESCRIPTION
Before:
```
$ echo "@tmi-sent-ts=1752027488850;room-id=239089342 :tmi.twitch.tv CLEARCHAT #supa8" | ./irc2text 
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
main.main()
	/home/supa/git/justgrep/cmd/irc2text/irc2text.go:27 +0x4ef
```


After:
```
$ echo "@tmi-sent-ts=1752027488850;room-id=239089342 :tmi.twitch.tv CLEARCHAT #supa8" | ./irc2text
[2025-07-09 02:18:08] #supa8 Chat has been cleared
```